### PR TITLE
Fixed format and flash scripts for Ubuntu 16.04

### DIFF
--- a/flash_sd-rev-ubuntu-16.04.sh
+++ b/flash_sd-rev-ubuntu-16.04.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+function pt_error()
+{
+    echo -e "\033[1;31mERROR: $*\033[0m"
+}
+
+function pt_warn()
+{
+    echo -e "\033[1;31mWARN: $*\033[0m"
+}
+
+function pt_info()
+{
+    echo -e "\033[1;32mINFO: $*\033[0m"
+}
+
+function pt_ok()
+{
+    echo -e "\033[1;33mOK: $*\033[0m"
+}
+
+
+
+SDCARD="$1"
+
+if [ -z "$SDCARD" ]; then
+    pt_error "Usage: $0 <SD card> (SD CARD: /dev/sdX  where X is your sd card number or /dev/mmcblkX where X is a letter)"
+    exit 1
+fi
+
+if [ $UID -ne 0 ]
+    then
+    pt_error "Please run as root."
+    exit
+fi
+
+
+pt_info "Umounting $out, please wait..."
+umount ${SDCARD}* >/dev/null 2>&1
+sleep 1
+sync
+
+sudo partprobe
+sleep 2
+sync
+sudo partprobe ${SDCARD}
+sleep 2
+
+
+set -e
+
+pt_warn "Flashing $SDCARD...."
+dd if=./boot0.bin conv=notrunc bs=1k seek=8 of=${SDCARD}
+dd if=./ub-m64-sdcard.bin conv=notrunc bs=1k seek=19096 of=${SDCARD}
+
+pt_info "Decompressing rootfs to $SDCARD"p2", please wait... (takes some time)"
+mkdir -p erootfs
+sudo partprobe ${SDCARD}
+sleep 4
+sudo mount $SDCARD"p2" erootfs
+tar -xvpzf rootfs_m64_rc6.tar.gz -C ./erootfs --numeric-ow
+sync
+sudo umount erootfs
+rm -fR erootfs
+
+set +e
+mkdir eboot
+sudo mount $SDCARD"p1" eboot
+tar -xvpzf boot_m64_rc6.tar.gz -C ./eboot  --no-same-owner
+sync
+sudo umount eboot
+rm -fR eboot
+
+pt_ok "Finished flashing $SDCARD!"
+pt_ok "You can remove the SD card and boot up on your board. Enjoy!"
+

--- a/format_sd-rev-ubuntu-16.04.sh
+++ b/format_sd-rev-ubuntu-16.04.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+function pt_error()
+{
+    echo -e "\033[1;31mERROR: $*\033[0m"
+}
+
+function pt_warn()
+{
+    echo -e "\033[1;31mWARN: $*\033[0m"
+}
+
+function pt_info()
+{
+    echo -e "\033[1;32mINFO: $*\033[0m"
+}
+
+function pt_ok()
+{
+    echo -e "\033[1;33mOK: $*\033[0m"
+}
+
+
+
+out="$1"
+
+if [ -z "$out" ]; then
+    pt_error "Usage: $0 <SD card> (SD CARD: /dev/sdX  or /dev/mmcblkX where X is your sd card number)"
+    exit 1
+fi
+
+if [ $UID -ne 0 ]
+    then
+    pt_error "Please run as root."
+    exit
+fi
+
+
+pt_info "Umounting $out, please wait..."
+sync
+umount ${out}* >/dev/null 2>&1
+sleep 1
+sync
+
+set -e
+pt_info "Formating sd card $out ..."
+
+part_position=20480   # KiB
+boot_size=80          # MiB
+# Create beginning of disk
+pt_info "Zeroing mbr on $out ..."
+dd if=/dev/zero bs=1M count=$((part_position/1024)) of="$out"
+sync
+
+pt_info "Creating partition on $out ..."
+# Add partition table
+cat <<EOF | fdisk "$out"
+o
+n
+p
+1
+$((part_position*2))
++${boot_size}M
+t
+c
+n
+p
+2
+$((part_position*2 + boot_size*1024*2))
+
+t
+2
+83
+w
+EOF
+
+sleep 1
+sync
+partprobe -s ${out}
+sync
+
+pt_warn "Formating $out ..."
+# Create boot file system (VFAT)
+dd if=/dev/zero bs=1M count=${boot_size} of=${out}p1
+mkfs.vfat -n boot -I ${out}p1
+
+# Create ext4 file system for rootfs
+mkfs.ext4 -F -b 4096 -E stride=2,stripe-width=1024 -L rootfs ${out}p2
+sync
+sudo tune2fs -O ^has_journal ${out}p2
+sync
+
+pt_ok "Done - Geometry created and sd card '$out' formatted, now flash the image with ./flash_sd.sh"
+


### PR DESCRIPTION
Due to an error of mmcblk0 created partition (not mmcblk01 and mmcblk02, but mmcblk0p1 and mmcblk0p2), I've modified the "${out}1" to "${out}p1" and ${out}2 to ${out}p2, in order to correctly detect the partition for "format_sd.sh" script completion. I've also modified the SDCARD"1" to SDCARD"p1" and SDCARD"2" to SDCARD"p2" in order to correctly detect and choose the partitions created in "format_sd.sh" script  for flashing with "flash_sd.sh" script.